### PR TITLE
[HTP-0002] rubicon adapter: change p_pos param default

### DIFF
--- a/rubicon/CHANGES.md
+++ b/rubicon/CHANGES.md
@@ -1,3 +1,8 @@
+# 2.1.5
+
+- Adapter changes:
+No longer defaulting the 'p_pos' param to 'btf'.  It will not be included in the bid request if it is not defined
+
 # 2.1.4
  
 - Testing file:

--- a/rubicon/rubicon-htb.js
+++ b/rubicon/rubicon-htb.js
@@ -408,7 +408,6 @@ function RubiconModule(configs) {
         var queryObj = {
             account_id: configs.accountId,
             size_id: rubiSizeIds[0],
-            p_pos: slotFirstPartyData.position ? slotFirstPartyData.position : 'btf',
             rp_floor: 0.01,
             rf: referrer ? referrer : '',
             p_screen_res: Browser.getScreenWidth() + 'x' + Browser.getScreenHeight(),
@@ -419,7 +418,13 @@ function RubiconModule(configs) {
             rand: Math.random(),
             dt: _getDigiTrustQueryParams()
         };
+
+        // Add p_pos only if it exists
+        if (slotFirstPartyData.position) {
+            queryObj.p_pos = slotFirstPartyData.position;
+        }
         /* eslint-enable camelcase */
+
         if (gdprConsent && privacyEnabled && typeof gdprConsent === 'object') {
             if (typeof gdprConsent.applies === 'boolean') {
                 queryObj.gdpr = Number(gdprConsent.applies);
@@ -744,7 +749,7 @@ function RubiconModule(configs) {
             partnerId: 'RubiconHtb',
             namespace: 'RubiconHtb',
             statsId: 'RUBI',
-            version: '2.1.4',
+            version: '2.1.5',
             targetingType: 'slot',
             enabledAnalytics: {
                 requestTime: true


### PR DESCRIPTION
<!--
Thank you for your pull request. 
Please use "[HTP-****] <Adapter Name>: Brief Description" as the title of this pull request.
For example, 
[HTP-0001] Example Adapter: Code Refactor

Please make sure this pull request fulfills all of the requirements in the Index Exchange's 
Adapter Code Submission Guidelines. Please refer to the following link for more details:
https://knowledgebase.indexexchange.com/display/ADAPTER/Adapter+Code+Submission+Guidelines
-->

## Type of Change
<!-- Select an item by changing [ ] to [x] -->
- [ ] New adapter
- [x] Feature Update
- [ ] Bug Fix
- [ ] Code Refactor
- [ ] Other

## Description of Change
<!-- Describe the changes in this pull request -->
No longer defaulting the 'p_pos' param to 'btf'.  It will not be included in the bid request if it is not defined

### Related Issue
<!-- This is an optional field. Delete this section if this pull request is not related to any issue. 
Please include the issue number after # below if this pull request is related to an issue -->
#
