### PR TITLE
Revert "[HTP-66] Beachfront: Unified ID Support"

### DIFF
--- a/beachfront/CHANGES.md
+++ b/beachfront/CHANGES.md
@@ -1,6 +1,3 @@
 
-# 1.1.0
-- Add support for the Unified ID
-
 # 1.0.0
 - Initial adapter implementation

--- a/beachfront/beachfront-htb-system-tests.js
+++ b/beachfront/beachfront-htb-system-tests.js
@@ -41,35 +41,6 @@ function getBidRequestRegex() {
 }
 
 function validateBidRequest(request) {
-    var data = JSON.parse(request.body);
-    expect(data.slots).toEqual([
-        {
-            slot: '1',
-            id: '3b16770b-17af-4d22-daff-9606bdf2c9c3',
-            bidfloor: 0.01,
-            sizes: [
-                {
-                    w: 728,
-                    h: 90
-                },
-                {
-                    w: 468,
-                    h: 60
-                }
-            ]
-        },
-        {
-            slot: '2',
-            id: '3b16770b-17af-4d22-daff-9606bdf2c9c3',
-            bidfloor: 0.02,
-            sizes: [
-                {
-                    w: 300,
-                    h: 250
-                }
-            ]
-        }
-    ]);
     expect(request.query.cb).toBeDefined();
 }
 
@@ -115,17 +86,6 @@ function getPassResponse() {
     return JSON.stringify(response);
 }
 
-function validateBidRequestWithPrivacy(request) {
-    var data = JSON.parse(request.body);
-    expect(data.gdpr).toBe(1);
-    expect(data.gdprConsent).toBe('TEST_GDPR_CONSENT_STRING');
-}
-
-function validateBidRequestWithAdSrvrOrg(request) {
-    var data = JSON.parse(request.body);
-    expect(data.tdid).toBe('TEST_ADSRVR_ORG_STRING');
-}
-
 module.exports = {
     getPartnerId: getPartnerId,
     getStatsId: getStatsId,
@@ -136,7 +96,5 @@ module.exports = {
     validateBidRequest: validateBidRequest,
     getValidResponse: getValidResponse,
     validateTargeting: validateTargeting,
-    getPassResponse: getPassResponse,
-    validateBidRequestWithPrivacy: validateBidRequestWithPrivacy,
-    validateBidRequestWithAdSrvrOrg: validateBidRequestWithAdSrvrOrg
+    getPassResponse: getPassResponse
 };

--- a/beachfront/beachfront-htb.js
+++ b/beachfront/beachfront-htb.js
@@ -259,26 +259,6 @@ function BeachfrontHtb(configs) {
             adapterName: __adapterName
         };
 
-        var tradeDeskId = null;
-        var identityData = returnParcels[0] && returnParcels[0].identityData;
-
-        if (identityData && identityData.AdserverOrgIp && identityData.AdserverOrgIp.data) {
-            var adsrvrUids = identityData.AdserverOrgIp.data.uids;
-            if (Utilities.isArray(adsrvrUids)) {
-                for (var j = 0; j < adsrvrUids.length; j++) {
-                    if (adsrvrUids[j].ext && adsrvrUids[j].ext.rtiPartner === 'TDID') {
-                        tradeDeskId = adsrvrUids[j].id;
-
-                        break;
-                    }
-                }
-            }
-        }
-
-        if (tradeDeskId) {
-            queryObj.tdid = tradeDeskId;
-        }
-
         /* ------------------------ Get consent information -------------------------
          * If you want to implement GDPR consent in your adapter, use the function
          * ComplianceService.gdpr.getConsent() which will return an object.


### PR DESCRIPTION
## Type of Change
<!-- Select an item by changing [ ] to [x] -->
- [ ] New adapter
- [ ] Feature Update
- [ ] Bug Fix
- [ ] Code Refactor
- [x] Other

## Description of Change
This Beachfront update has been in canary for months, and in trying to keep canary clean (+ resolve some conflicts), we're reverting this PR.

### Related Issue
https://github.com/indexexchange/ix-library-adapters/pull/113