### PR TITLE
[HTP-65] Quantcast: Convert size array to size object

### DIFF
--- a/quantcast/quantcast-htb.js
+++ b/quantcast/quantcast-htb.js
@@ -149,7 +149,7 @@ function QuantcastHtb(configs) {
                 {
                     banner: {
                         battr: parcel.xSlotRef.battr || configs.battr || [],
-                        sizes: parcel.xSlotRef.sizes || makeSizesFromHtSlot(parcel.htSlot.getSizes()),
+                        sizes: makeSizesFromHtSlot(parcel.xSlotRef.sizes || parcel.htSlot.getSizes()),
                         pos: parcel.xSlotRef.adPos || configs.adPos || 0
                     },
                     placementCode: parcel.htSlot.getId(),


### PR DESCRIPTION
## Type of Change
<!-- Select an item by changing [ ] to [x] -->
- [ ] New adapter
- [ ] Feature Update
- [x] Bug Fix
- [ ] Code Refactor
- [ ] Other

## Description of Change
<!-- Describe the changes in this pull request -->
Index is sending slot sizes as a 2D dimensional array, however Quantcast expects them to be an array of objects. This PR always converts the 2D dimensional array to an array of objects.
