### PR TITLE
[HTP-****] AppNexus: Add support for reading `optData` user and site values

### DIFF
--- a/app-nexus/CHANGES.md
+++ b/app-nexus/CHANGES.md
@@ -1,3 +1,8 @@
+Version 2.4.1
+=============
+
+- Added support for first party data (optData)
+
 Version 2.4.0
 =============
 

--- a/app-nexus/app-nexus-htb.js
+++ b/app-nexus/app-nexus-htb.js
@@ -75,7 +75,7 @@ function AppNexusHtb(configs) {
      */
     var __baseUrl;
 
-    var __version = '2.4.0';
+    var __version = '2.4.1';
 
     /* =====================================
      * Functions
@@ -91,7 +91,7 @@ function AppNexusHtb(configs) {
      * @param  {Object[]} returnParcels Array of parcels.
      * @return {Object}                 Request object.
      */
-    function __generateRequestObj(returnParcels) {
+    function __generateRequestObj(returnParcels, optData) {
         //? if (DEBUG){
         var results = Inspector.validate({
             type: 'array',
@@ -171,6 +171,43 @@ function AppNexusHtb(configs) {
                             value: keywordsObj[key]
                         });
                     });
+            }
+
+            /*
+             * Check for a "optData" argument passed to __generateRequestObj();
+             * Push both user and site optional data into the `keywords` key on the `tag`.
+            */
+
+            if (Utilities.isObject(optData)) {
+                if (!Utilities.isEmpty(optData.keyValues.user)) {
+                    var userKeywords = optData.keyValues.user;
+                    if (!tag.hasOwnProperty('keywords')) {
+                        tag.keywords = [];
+                    }
+
+                    Object.keys(userKeywords)
+                        .forEach(function (key) {
+                            tag.keywords.push({
+                                key: key,
+                                value: userKeywords[key]
+                            });
+                        });
+                }
+
+                if (!Utilities.isEmpty(optData.keyValues.site)) {
+                    var siteKeywords = optData.keyValues.site;
+                    if (!tag.hasOwnProperty('keywords')) {
+                        tag.keywords = [];
+                    }
+
+                    Object.keys(siteKeywords)
+                        .forEach(function (key) {
+                            tag.keywords.push({
+                                key: key,
+                                value: siteKeywords[key]
+                            });
+                        });
+                }
             }
 
             queryObj.tags.push(tag);


### PR DESCRIPTION
## Type of Change
- [ ] New adapter
- [x] Feature Update
- [ ] Bug Fix
- [ ] Code Refactor
- [ ] Other

## Description of Change

This PR reads both `user` and `site`,  `optData` and appends to the tags object for each ad.

Supports [this API](https://kb.indexexchange.com/publishers/key_values/set_up_custom_targeting.htm).

Some questions to both Index and Xandr team would be:
- There seem to be no test cases for `optData.keyValues`, so this PR does not add any new tests. Should it?
- The reading of keywords from the xSlot is now defunct? If yes, happy to remove that code path.

@ix-certification @jsnellbaker 