### PR TITLE
[HTP-****] AppNexus-Network: Add support for reading optData user and site values

### DIFF
--- a/app-nexus-network/CHANGES.md
+++ b/app-nexus-network/CHANGES.md
@@ -1,5 +1,11 @@
+Version 2.6.0
+=============
+
+- Added support for first party data (optData)
+
 Version 2.5.0
 =============
+
 - Added USP (CCPA) support to bidder
 
 Version 2.4.0

--- a/app-nexus-network/app-nexus-network-htb.js
+++ b/app-nexus-network/app-nexus-network-htb.js
@@ -75,7 +75,7 @@ function AppNexusNetworkHtb(configs) {
      */
     var __baseUrl;
 
-    var __version = '2.5.0';
+    var __version = '2.6.0';
 
     /* =====================================
      * Functions
@@ -91,7 +91,7 @@ function AppNexusNetworkHtb(configs) {
      * @param  {Object[]} returnParcels Array of parcels.
      * @return {Object}                 Request object.
      */
-    function __generateRequestObj(returnParcels) {
+    function __generateRequestObj(returnParcels, optData) {
         //? if (DEBUG){
         var results = Inspector.validate({
             type: 'array',
@@ -171,6 +171,43 @@ function AppNexusNetworkHtb(configs) {
                             value: keywordsObj[key]
                         });
                     });
+            }
+            
+            /*
+             * Check for a "optData" argument passed to __generateRequestObj();
+             * Push both user and site optional data into the `keywords` key on the `tag`.
+            */
+
+            if (Utilities.isObject(optData)) {
+                if (!Utilities.isEmpty(optData.keyValues.user)) {
+                    var userKeywords = optData.keyValues.user;
+                    if (!tag.hasOwnProperty('keywords')) {
+                        tag.keywords = [];
+                    }
+
+                    Object.keys(userKeywords)
+                        .forEach(function (key) {
+                            tag.keywords.push({
+                                key: key,
+                                value: userKeywords[key]
+                            });
+                        });
+                }
+
+                if (!Utilities.isEmpty(optData.keyValues.site)) {
+                    var siteKeywords = optData.keyValues.site;
+                    if (!tag.hasOwnProperty('keywords')) {
+                        tag.keywords = [];
+                    }
+
+                    Object.keys(siteKeywords)
+                        .forEach(function (key) {
+                            tag.keywords.push({
+                                key: key,
+                                value: siteKeywords[key]
+                            });
+                        });
+                }
             }
 
             queryObj.tags.push(tag);


### PR DESCRIPTION
## Type of Change
- [ ] New adapter
- [x] Feature Update
- [ ] Bug Fix
- [ ] Code Refactor
- [ ] Other

## Description of Change

This PR reads both `user` and `site`,  `optData` and appends to the tags object for each ad.

Supports [this API](https://kb.indexexchange.com/publishers/key_values/set_up_custom_targeting.htm).

Added this PR to keep this adapter and the `appnexus` adapter at feature parity based on [comment](https://github.com/indexexchange/ix-library-adapters/pull/221#issuecomment-834323907) by @jsnellbaker 

One questions remains:
- Is there a way to add tests to support the proper use of this feature? The current test cases all pass with this update.

@ix-certification @jsnellbaker 